### PR TITLE
fixed bug in critical/diplomatic switch in core.py line 104

### DIFF
--- a/lbp_print/core.py
+++ b/lbp_print/core.py
@@ -101,7 +101,7 @@ class Resource:
         try:
             if schema_info["type"] == "critical":
                 xslt_document_type = "critical"
-            elif schema_info["type"] == "critical":
+            elif schema_info["type"] == "diplomatic":
                 xslt_document_type = "diplomatic"
         except KeyError:
             raise AttributeError(


### PR DESCRIPTION
This fixes in a small bug at line 104 that was preventing conversion of "diplomatic" transcriptions. 

lbp-print-api is currently point to this branch (lombardpress/lbp_print/upstream), but it would be good to get this change into your master as well. 

When we get the time (maybe a Saturday someday) we should go through and organize the relationships of these repos and their branches.